### PR TITLE
Altera DCC/UFBA para IC/UFBA.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
         <div class="row">
           <div class="col-lg-6 text-center text-lg-left">
             <h3>We are a <span>collaborative</span> research group.</h3>
-            <p> ARIES LAB is a research team at the Department of Computer Science, Federal University of Bahia (UFBA) together with the Federal University of Lavras (UFLA) and the State University of Feira de Santana (UEFS).</p>
+            <p> ARIES LAB is a research team at the Institute of Computing at Federal University of Bahia (UFBA) together with the Federal University of Lavras (UFLA) and the State University of Feira de Santana (UEFS).</p>
           </div>
           <div class="col-lg-6 cta-btn-container">
             <div class="row" >


### PR DESCRIPTION
Olá!

Na página inicial, altera a referência para Instituto de Computação da UFBA, ao invés do DCC